### PR TITLE
fix: level c errors fixed

### DIFF
--- a/src/main/java/acme/features/any/campaign/AnyCampaignShowService.java
+++ b/src/main/java/acme/features/any/campaign/AnyCampaignShowService.java
@@ -36,7 +36,7 @@ public class AnyCampaignShowService extends AbstractService<Any, Campaign> {
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "spokesperson.identity.fullName", "draftMode");
+		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "spokesperson.identity.fullName", "monthsActive", "effort", "draftMode");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignCreateService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignCreateService.java
@@ -59,7 +59,7 @@ public class SpokespersonCampaignCreateService extends AbstractService<Spokesper
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "draftMode");
+		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "monthsActive", "effort", "draftMode");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignDeleteService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignDeleteService.java
@@ -60,7 +60,7 @@ public class SpokespersonCampaignDeleteService extends AbstractService<Spokesper
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "draftMode");
+		super.unbindObject(this.campaign, "ticker", "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "moreInfo", "monthsActive", "effort", "draftMode");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignListService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignListService.java
@@ -34,7 +34,7 @@ public class SpokespersonCampaignListService extends AbstractService<Spokesperso
 
 	@Override
 	public void unbind() {
-		super.unbindObjects(this.campaigns, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "spokesperson.identity.fullName");
+		super.unbindObjects(this.campaigns, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "moreInfo", "monthsActive", "effort", "spokesperson.identity.fullName");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignPublishService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignPublishService.java
@@ -65,7 +65,7 @@ public class SpokespersonCampaignPublishService extends AbstractService<Spokespe
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "draftMode");
+		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "moreInfo", "monthsActive", "effort", "draftMode");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignShowService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignShowService.java
@@ -34,7 +34,7 @@ public class SpokespersonCampaignShowService extends AbstractService<Spokesperso
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "draftMode", "spokesperson.identity.fullName");
+		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "moreInfo", "monthsActive", "effort", "draftMode", "spokesperson.identity.fullName");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignUpdateService.java
+++ b/src/main/java/acme/features/spokesperson/campaign/SpokespersonCampaignUpdateService.java
@@ -58,7 +58,7 @@ public class SpokespersonCampaignUpdateService extends AbstractService<Spokesper
 
 	@Override
 	public void unbind() {
-		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "draftMode");
+		super.unbindObject(this.campaign, "ticker", "name", "description", "startMoment", "endMoment", "moreInfo", "moreInfo", "monthsActive", "effort", "draftMode");
 	}
 
 }

--- a/src/main/java/acme/features/spokesperson/milestone/SpokespersonMilestoneDeleteService.java
+++ b/src/main/java/acme/features/spokesperson/milestone/SpokespersonMilestoneDeleteService.java
@@ -42,7 +42,7 @@ public class SpokespersonMilestoneDeleteService extends AbstractService<Spokespe
 
 	@Override
 	public void validate() {
-		super.validateObject(this.milestone);
+		;
 	}
 
 	@Override

--- a/src/main/resources/WEB-INF/views/any/campaign/form.jsp
+++ b/src/main/resources/WEB-INF/views/any/campaign/form.jsp
@@ -11,6 +11,8 @@
 	<acme:form-moment code="any.campaign.form.label.endMoment" path="endMoment"/>
 	<acme:form-url code="any.campaign.form.label.moreInfo" path="moreInfo"/>
 	<acme:form-textbox code="any.campaign.form.label.spokesperson" path="spokesperson.identity.fullName"/>
+	<acme:form-double code="any.campaign.form.label.monthsActive" path="monthsActive"/>
+	<acme:form-double code="any.campaign.form.label.effort" path="effort"/>
 	
 	<acme:button code="any.campaign.form.button.milestones" action="/any/milestone/list?campaignId=${id}"/>
 	<acme:button code="any.campaign.form.button.spokesperson" action="/any/spokesperson/show?campaignId=${id}"/>

--- a/src/main/resources/WEB-INF/views/any/campaign/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/any/campaign/messages-en.i18n
@@ -8,6 +8,8 @@ any.campaign.form.label.startMoment = Start moment:
 any.campaign.form.label.endMoment = End moment:
 any.campaign.form.label.moreInfo = More info: (Optional)
 any.campaign.form.label.spokesperson = Spokesperson:
+any.campaign.form.label.monthsActive = Months active:
+any.campaign.form.label.effort = Effort:
 
 any.campaign.form.button.milestones = Milestones
 any.campaign.form.button.spokesperson = Spokesperson

--- a/src/main/resources/WEB-INF/views/any/campaign/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/any/campaign/messages-es.i18n
@@ -8,6 +8,8 @@ any.campaign.form.label.startMoment = Momento inicio:
 any.campaign.form.label.endMoment = Momento fin:
 any.campaign.form.label.moreInfo = Más información: (Optional)
 any.campaign.form.label.spokesperson = Portavoz:
+any.campaign.form.label.monthsActive = Meses activa:
+any.campaign.form.label.effort = Esfuerzo:
 
 any.campaign.form.button.milestones = Hitos
 any.campaign.form.button.spokesperson = Portavoz

--- a/src/main/resources/WEB-INF/views/any/milestone/list.jsp
+++ b/src/main/resources/WEB-INF/views/any/milestone/list.jsp
@@ -4,8 +4,7 @@
 <%@taglib prefix="acme" uri="http://acme-framework.org/"%>
 
 <acme:list>
-	<acme:list-column code="any.milestone.list.label.title" path="title" width="60%"/>	
-	<acme:list-column code="any.milestone.list.label.effort" path="effort" width="40%"/>
-	<acme:list-hidden path="achievements"/>
-	<acme:list-hidden path="kind"/>
+	<acme:list-column code="any.milestone.list.label.title" path="title" width="40%"/>	
+	<acme:list-column code="any.milestone.list.label.effort" path="effort" width="30%"/>
+	<acme:list-column code="any.milestone.list.label.kind" path="kind" width="30%"/>
 </acme:list>

--- a/src/main/resources/WEB-INF/views/any/milestone/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/any/milestone/messages-en.i18n
@@ -8,3 +8,4 @@ any.milestone.form.label.kind = Kind:
 
 any.milestone.list.label.title = Title
 any.milestone.list.label.effort = Effort
+any.milestone.list.label.kind = Kind

--- a/src/main/resources/WEB-INF/views/any/milestone/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/any/milestone/messages-es.i18n
@@ -8,3 +8,4 @@ any.milestone.form.label.kind = Tipo:
 
 any.milestone.list.label.title = Título
 any.milestone.list.label.effort = Esfuerzo
+any.milestone.list.label.kind = Tipo

--- a/src/main/resources/WEB-INF/views/spokesperson/campaign/form.jsp
+++ b/src/main/resources/WEB-INF/views/spokesperson/campaign/form.jsp
@@ -5,11 +5,13 @@
 
 <acme:form> 
 	<acme:form-textbox code="spokesperson.campaign.form.label.ticker" path="ticker"/>
-	<acme:form-textbox code="spokesperson.campaign.form.label.name" path="name"/>	
+	<acme:form-textbox code="spokesperson.campaign.form.label.name" path="name"/>
 	<acme:form-textarea code="spokesperson.campaign.form.label.description" path="description"/>
 	<acme:form-moment code="spokesperson.campaign.form.label.startMoment" path="startMoment"/>
 	<acme:form-moment code="spokesperson.campaign.form.label.endMoment" path="endMoment"/>
 	<acme:form-url code="spokesperson.campaign.form.label.moreInfo" path="moreInfo"/>
+	<acme:form-double code="spokesperson.campaign.form.label.monthsActive" path="monthsActive" readonly="true"/>
+	<acme:form-double code="spokesperson.campaign.form.label.effort" path="effort" readonly="true"/>
 
 	<jstl:choose>	 
 		<jstl:when test="${_command == 'show' && draftMode == false}">

--- a/src/main/resources/WEB-INF/views/spokesperson/campaign/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/spokesperson/campaign/messages-en.i18n
@@ -2,11 +2,13 @@ spokesperson.campaign.form.title = Campaign details
 spokesperson.campaign.list.title = Listing of campaigns
 
 spokesperson.campaign.form.label.ticker = Ticker:
-spokesperson.campaign.form.label.name = Name: 
+spokesperson.campaign.form.label.name = Name:
 spokesperson.campaign.form.label.description = Description:
 spokesperson.campaign.form.label.startMoment = Start moment:
 spokesperson.campaign.form.label.endMoment = End moment:
 spokesperson.campaign.form.label.moreInfo = More info: (Optional)
+spokesperson.campaign.form.label.monthsActive = Months active:
+spokesperson.campaign.form.label.effort = Effort:
 		
 spokesperson.campaign.form.button.milestones = Milestones
 spokesperson.campaign.form.button.update = Update

--- a/src/main/resources/WEB-INF/views/spokesperson/campaign/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/spokesperson/campaign/messages-es.i18n
@@ -7,6 +7,8 @@ spokesperson.campaign.form.label.description = Descripción:
 spokesperson.campaign.form.label.startMoment = Momento inicio:
 spokesperson.campaign.form.label.endMoment = Momento fin:
 spokesperson.campaign.form.label.moreInfo = Más información: (Opcional)
+spokesperson.campaign.form.label.monthsActive = Meses activa:
+spokesperson.campaign.form.label.effort = Esfuerzo:
 		
 spokesperson.campaign.form.button.milestones = Hitos
 spokesperson.campaign.form.button.update = Actualizar

--- a/src/main/resources/WEB-INF/views/spokesperson/milestone/list.jsp
+++ b/src/main/resources/WEB-INF/views/spokesperson/milestone/list.jsp
@@ -4,10 +4,9 @@
 <%@taglib prefix="acme" uri="http://acme-framework.org/"%>
 
 <acme:list>
-	<acme:list-column code="spokesperson.milestone.list.label.title" path="title" width="60%"/>	
-	<acme:list-column code="spokesperson.milestone.list.label.effort" path="effort" width="40%"/>
-	<acme:list-hidden path="achievements"/>
-	<acme:list-hidden path="kind"/>
+	<acme:list-column code="spokesperson.milestone.list.label.title" path="title" width="40%"/>	
+	<acme:list-column code="spokesperson.milestone.list.label.effort" path="effort" width="30%"/>
+	<acme:list-column code="spokesperson.milestone.list.label.kind" path="kind" width="30%"/>
 </acme:list>
 
 <jstl:if test="${showCreate}">

--- a/src/main/resources/WEB-INF/views/spokesperson/milestone/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/spokesperson/milestone/messages-en.i18n
@@ -12,5 +12,6 @@ spokesperson.milestone.form.button.delete = Delete
 
 spokesperson.milestone.list.label.title = Title
 spokesperson.milestone.list.label.effort = Effort
+spokesperson.milestone.list.label.kind = Kind
 
 spokesperson.milestone.list.button.create = Create

--- a/src/main/resources/WEB-INF/views/spokesperson/milestone/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/spokesperson/milestone/messages-es.i18n
@@ -12,5 +12,6 @@ spokesperson.milestone.form.button.delete = Borrar
 
 spokesperson.milestone.list.label.title = Título
 spokesperson.milestone.list.label.effort = Esfuerzo
+spokesperson.milestone.list.label.kind = Tipo
 
 spokesperson.milestone.list.button.create = Crear


### PR DESCRIPTION
Student 2 level C errors fixed. When showing a campaign, now derivated atributtes are also showed. When trying to delete an empty milestones, now it is possible.